### PR TITLE
fix typing issue

### DIFF
--- a/src/types/Router.ts
+++ b/src/types/Router.ts
@@ -1,4 +1,4 @@
-import * as KoaRouter from "koa-router";
+import KoaRouter from "koa-router";
 
 export class Router extends KoaRouter {
   opts: KoaRouter.IRouterOptions;


### PR DESCRIPTION
as koa-router's latest declare exports now a constructor.
`import * as KoaRouter from "koa-router"`will cause  a TS2507 error when compiling

```
/Users/raphaelsoul/projects/zuma/nodejs/proxy/node_modules/static-koa-router/types/Router.d.ts(2,37): error TS2507: Type 'typeof Router' is not a constructor function type.
(node:79733) UnhandledPromiseRejectionWarning: Error: TypeScript: Compilation failed
    at Output.mightFinish (/Users/raphaelsoul/projects/zuma/nodejs/proxy/node_modules/gulp-typescript/release/output.js:130:43)
    at applySourceMap.then.appliedSourceMap (/Users/raphaelsoul/projects/zuma/nodejs/proxy/node_modules/gulp-typescript/release/output.js:43:22)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
(node:79733) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:79733) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
TypeScript: 1 semantic error
TypeScript: emit succeeded (with errors)
```